### PR TITLE
Fix confirmation prompts rejecting lowercase y/n input

### DIFF
--- a/dropkit/main.py
+++ b/dropkit/main.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 import typer
 from rich.console import Console
 from rich.panel import Panel
-from rich.prompt import Confirm, Prompt
+from rich.prompt import Prompt
 from rich.table import Table
 
 from dropkit.api import DigitalOceanAPI, DigitalOceanAPIError
@@ -405,7 +405,7 @@ def cleanup_ssh_entries(
         console.print(f"[dim]SSH config entry for {ssh_hostname} not found (skipped)[/dim]")
 
     # Clean up known_hosts
-    should_remove = not prompt_known_hosts or Confirm.ask(
+    should_remove = not prompt_known_hosts or typer.confirm(
         "Remove SSH fingerprint from known_hosts?", default=True
     )
 
@@ -2440,7 +2440,7 @@ def config_ssh(
             console.print(
                 f"[yellow]⚠[/yellow] SSH config entry for '{ssh_hostname}' already exists"
             )
-            if not Confirm.ask("Do you want to update it?", default=False):
+            if not typer.confirm("Do you want to update it?", default=False):
                 console.print("[dim]Aborted[/dim]")
                 return
 
@@ -4437,7 +4437,7 @@ def add_ssh_key_cmd(
             console.print()
 
             # Ask for confirmation to rename
-            confirm = Confirm.ask(
+            confirm = typer.confirm(
                 "Do you want to rename this key to follow dropkit naming convention?",
                 default=True,
             )
@@ -4528,8 +4528,8 @@ def delete_ssh_key_cmd(
 
         # Ask for confirmation
         console.print()
-        confirm = Confirm.ask(
-            "[yellow]Are you sure you want to delete this SSH key?[/yellow]",
+        confirm = typer.confirm(
+            "Are you sure you want to delete this SSH key?",
             default=False,
         )
 


### PR DESCRIPTION
## Summary
- Rich's `Confirm.ask` rejects lowercase `y` in certain terminal conditions, requiring users to type uppercase `Y` despite the prompt showing `[y/n]`
- Replaced all 4 `Confirm.ask` calls with `typer.confirm()`, which uses Click's confirm under the hood and handles case-insensitive input reliably
- Removed unused `Confirm` import from `rich.prompt`

## Reproducer
```
Remove SSH fingerprint from known_hosts? [y/n] (y): y
Please enter Y or N
Remove SSH fingerprint from known_hosts? [y/n] (y): Y   ← only uppercase works
```

## Test plan
- [ ] Run `dropkit destroy <name>` and verify lowercase `y` is accepted at the known_hosts prompt
- [ ] Run `dropkit config ssh` with an existing entry and verify the update prompt works
- [ ] Run `dropkit ssh-key add` with a rename prompt and verify it works
- [ ] Run `dropkit ssh-key delete` and verify the confirmation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)