### PR TITLE
Add helper instructions to generate DO token

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ Optional environment variable overrides: `DROPLET_NAME`, `DROPLET_REGION`,
 
 ### Creating Your Token
 
+Run `dropkit init`; it can open a helper page for quickly selecting the minimum required scopes.
+
+**Manual approach:**
+
 1. Go to [DigitalOcean API Tokens](https://cloud.digitalocean.com/account/api/tokens)
 2. Click **Generate New Token** with name "dropkit-cli"
 3. Select **Custom Scopes** (recommended) or **Full Access** (simpler)

--- a/dropkit/main.py
+++ b/dropkit/main.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import time
+import webbrowser
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -45,6 +46,7 @@ console = Console()
 # DigitalOcean snapshot storage rate: $0.06/GB/month
 # https://docs.digitalocean.com/products/snapshots/details/pricing/
 SNAPSHOT_COST_PER_GB_MONTHLY = 0.06
+TOKEN_HELPER_PATH = Path(__file__).parent / "templates" / "token-helper.html"
 
 
 @app.callback()
@@ -1657,6 +1659,17 @@ def init(
 
     # Prompt for DigitalOcean API token
     console.print("\n[bold]DigitalOcean API Token[/bold]")
+    console.print(
+        "Need a token? dropkit can show a helper page for quickly selecting the "
+        "minimum required scopes."
+    )
+    if Confirm.ask("[cyan]Open token helper page in your browser?[/cyan]", default=True):
+        helper_url = TOKEN_HELPER_PATH.resolve().as_uri()
+        if webbrowser.open(helper_url):
+            console.print("[green]✓[/green] Opened token helper page in your browser")
+        else:
+            console.print("[yellow]Could not open your browser automatically.[/yellow]")
+            console.print(f"Open this URL manually: [cyan]{helper_url}[/cyan]")
     console.print("Get your token from: https://cloud.digitalocean.com/account/api/tokens")
     token = Prompt.ask("[cyan]Enter your DO API token[/cyan]", password=True)
 

--- a/dropkit/templates/token-helper.html
+++ b/dropkit/templates/token-helper.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>dropkit API token helper</title>
+  <style>
+    body {
+      color: #1f2937;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+      margin: 2rem auto;
+      max-width: 760px;
+      padding: 0 1rem;
+    }
+    a.bookmarklet {
+      background: #0069ff;
+      border-radius: 0.5rem;
+      color: white;
+      display: inline-block;
+      font-weight: 700;
+      margin: 0.5rem 0;
+      padding: 0.65rem 0.9rem;
+      text-decoration: none;
+    }
+    code, pre { background: #f3f4f6; border-radius: 0.25rem; padding: 0.15rem 0.3rem; }
+    li { margin: 0.5rem 0; }
+    .note { background: #eff6ff; border-left: 4px solid #0069ff; padding: 0.75rem 1rem; }
+  </style>
+</head>
+<body>
+  <h1>dropkit API token helper</h1>
+  <p>This page helps you create a DigitalOcean API token with the scopes dropkit needs.</p>
+
+  <h2>Fast scope selection</h2>
+  <ol>
+    <li>Drag <a class="bookmarklet" href="javascript:(async()=&gt;{const NAME=&quot;dropkit-cli&quot;;const SCOPES=[&quot;account:read&quot;,&quot;actions:read&quot;,&quot;droplet:create&quot;,&quot;droplet:read&quot;,&quot;droplet:update&quot;,&quot;droplet:delete&quot;,&quot;image:create&quot;,&quot;image:read&quot;,&quot;image:update&quot;,&quot;image:delete&quot;,&quot;project:read&quot;,&quot;project:update&quot;,&quot;regions:read&quot;,&quot;sizes:read&quot;,&quot;snapshot:read&quot;,&quot;snapshot:delete&quot;,&quot;ssh_key:create&quot;,&quot;ssh_key:read&quot;,&quot;ssh_key:update&quot;,&quot;ssh_key:delete&quot;,&quot;tag:read&quot;,&quot;tag:create&quot;,&quot;vpc:read&quot;];const sleep=ms=&gt;new Promise(r=&gt;setTimeout(r,ms));const all=()=&gt;[...document.querySelectorAll(&#x27;input[type=&quot;checkbox&quot;]&#x27;)];const scopeBoxes=()=&gt;[...document.querySelectorAll(&#x27;input[type=&quot;checkbox&quot;][data-testid=&quot;checkbox-input&quot;]&#x27;)];const find=v=&gt;scopeBoxes().find(i=&gt;i.value===v||i.name===v);const setValue=(i,v)=&gt;{if(!i)return;let d=Object.getOwnPropertyDescriptor(Object.getPrototypeOf(i),&quot;value&quot;);d?.set?d.set.call(i,v):i.value=v;i.dispatchEvent(new Event(&quot;input&quot;,{bubbles:true}));i.dispatchEvent(new Event(&quot;change&quot;,{bubbles:true}))};const tokenName=()=&gt;document.querySelector(&#x27;input#name[name=&quot;name&quot;],input[name=&quot;name&quot;],input#name&#x27;)||[...document.querySelectorAll(&quot;input&quot;)].find(i=&gt;/enter token name|token name/i.test(i.placeholder||&quot;&quot;)||/enter token name|token name/i.test(i.getAttribute(&quot;aria-label&quot;)||&quot;&quot;));const clickOn=i=&gt;{if(i&amp;&amp;!i.checked)i.click()};const clickOff=i=&gt;{if(i&amp;&amp;i.checked)i.click()};setValue(tokenName(),NAME);document.querySelector(&#x27;#scope_type-custom&#x27;)?.click();await sleep(300);all().filter(i=&gt;i.checked).forEach(clickOff);await sleep(500);for(const ns of [...new Set(SCOPES.map(s=&gt;s.split(&#x27;:&#x27;)[0]))]){let top=find(ns);let group=top?.closest(&#x27;div[class*=&quot;GranularScopesPermissionsGroupWrapper&quot;]&#x27;);group?.querySelector(&#x27;button[aria-label=&quot;plus&quot;]&#x27;)?.click();await sleep(150)}let missing=[];for(const s of SCOPES){let i=find(s);if(!i&amp;&amp;s.endsWith(&#x27;:read&#x27;))i=find(s.split(&#x27;:&#x27;)[0]);if(i)clickOn(i);else missing.push(s)}if(missing.length)alert(&quot;Could not find scopes:\n&quot;+missing.join(&quot;\n&quot;));})()">dropkit scopes</a> to your bookmarks bar.</li>
+    <li>Open the <a href="https://cloud.digitalocean.com/account/api/tokens/new" target="_blank" rel="noopener noreferrer">DigitalOcean API token creation page</a>.</li>
+    <li>Click the <strong>dropkit scopes</strong> bookmark you just created.</li>
+    <li>It fills in the token name <code>dropkit-cli</code> and selects the required custom scopes.</li>
+    <li>Review the selected scopes. There should be <strong>23 selected scopes</strong>, then click <strong>Generate Token</strong>.</li>
+    <li>Copy the token and paste it into <code>dropkit init</code>.</li>
+  </ol>
+
+  <p class="note">If your browser hides the bookmarks bar, enable it first, then drag the blue link above into it.</p>
+</body>
+</html>


### PR DESCRIPTION
I noticed that the initial config process is a bit painful, since it requires creating a DO token and manually selecting the 23 scopes for it (if one wants to have a minimally scoped token).

I created a bookmarklet that quickly fills the name and the scopes in the DO token creation page, and I put it in an HTML file (along with instructions on how to use it to create the token). The user can choose to see those instructions when running `dropkit init`. Here's a recording of what it looks like:


https://github.com/user-attachments/assets/3253df1b-7af3-4cc2-b587-840988e36dfb

And once the token is generated, one can go back to the terminal and paste it.


I went with this approach rather than just adding the bookmarklet to the `README.md` file, because GitHub does not render `javascript:` links. Hopefully this doesn't add to much friction.
